### PR TITLE
Add shields to readme; minor doc enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+<p align="center">
+  <a title="tdene.github.io/synth_opt_adders" href="https://tdene.github.io/synth_opt_adders"><img src="https://img.shields.io/website?longCache=true&style=flat-square&label=tdene.github.io%2Fsynth_opt_adders&logo=GitHub&logoColor=fff&up_color=blueviolet&up_message=Read%20now%20%E2%9E%9A&url=https%3A%2F%2Ftdene.github.io%2Fsynth_opt_adders%2Findex.html"></a><!--
+  -->
+  <a title="Apache-2.0" href="https://github.com/tdene/synth_opt_adders/blob/main/LICENSE"><img src="https://img.shields.io/github/license/tdene/synth_opt_adders?longCache=true&style=flat-square&logo=Apache&label=Code"></a><!--
+  -->
+  <a title="'config' workflow Status"
+     href="https://github.com/VUnit/vunit/actions?query=workflow%3Aconfig"
+  ><img alt="'config' workflow Status" src="https://img.shields.io/github/workflow/status/tdene/synth_opt_adders/Python%20package/main?longCache=true&style=flat-square&label=config&logo=GitHub%20Actions&logoColor=fff"
+  /></a><!--
+  -->
+  <a title="'docs' workflow Status"
+     href="https://github.com/VUnit/vunit/actions?query=workflow%3Adocs"
+  ><img alt="'docs' workflow Status" src="https://img.shields.io/github/workflow/status/tdene/synth_opt_adders/docs/main?longCache=true&style=flat-square&label=docs&logo=GitHub%20Actions&logoColor=fff"
+  /></a>
+</p>
+
 # Prefix tree generation scripts
 
 ## Table of Contents

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -80,7 +80,7 @@ if (ROOT / "_theme").is_dir():
     html_theme = "_theme"
     html_theme_options = {
         'logo_only': True,
-        'home_breadcrumbs': False,
+        'home_breadcrumbs': True,
         'vcs_pageview_mode': 'blob',
     }
 else:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,6 +46,7 @@ master_doc = 'index'
 
 project = 'Parallel prefix tree generation and exploration'
 author = 'Teodor-Dumitru Ene'
+copyright = 'Teodor-Dumitru Ene'
 
 version = "0.0.2"
 release = version  # The full version, including alpha/beta/rc tags.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,4 +1,5 @@
 Parallel Prefix Tree generation and exploration
+###############################################
 
 Contents:
 


### PR DESCRIPTION
This PR adds shields to the README, so it's easier to find the documentation site and to see the status of CI.

Moreover, some minor enhacements are applied to the doc:

- Have a header in the `index.rst`, which is used as the title of the site.
- Show breadcrumbs on Home, since there is no 'banner'.
- Add field copyright to the configuration, because that's the one used on the footer of the site (rather than `author`).

See https://umarcor.github.io/synth_opt_adders/.