### PR TITLE
doc: use pybtex (sphinxcontrib-bibtex) to handle references

### DIFF
--- a/doc/References.rst
+++ b/doc/References.rst
@@ -1,0 +1,7 @@
+.. _References:
+
+References
+##########
+
+.. bibliography::
+  :labelprefix: R

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,8 +19,12 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
+    'sphinxcontrib.bibtex',
 ]
+
+bibtex_default_style = 'plain'
+bibtex_bibfiles = [str(ROOT / 'refs.bib')]
 
 napoleon_google_docstring = True
 napoleon_numpy_docstring = True

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,12 +1,19 @@
 Parallel Prefix Tree generation and exploration
 ###############################################
 
+This is an example cite: :cite:p:`tdene21`.
+
 Contents:
 
 .. toctree::
    :maxdepth: 2
 
    src/pptrees
+
+.. toctree::
+   :caption: Appendix
+
+   References
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/doc/refs.bib
+++ b/doc/refs.bib
@@ -1,0 +1,10 @@
+@INPROCEEDINGS{tdene21,
+  author={Ene, Teodor-Dumitru and Stine, James E.},
+  booktitle={2021 IEEE 39th International Conference on Computer Design (ICCD)},
+  title={A Comprehensive Exploration of the Parallel Prefix Adder Tree Space},
+  year={2021},
+  volume={},
+  number={},
+  pages={125-129},
+  doi={10.1109/ICCD53106.2021.00030}
+}

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
 sphinx
-git+https://github.com/tdene/synth_opt_adders.git
+sphinxcontrib-bibtex


### PR DESCRIPTION
Since this seems to be an academic project, [pybtex](https://pybtex.org/) can be a good fit to handle references through bib files. This PR adds `refs.bib` and `sphinxcontrib-bibtex`. A referenced is cited for illustration. See https://umarcor.github.io/synth_opt_adders/index.html.

Other examples:

- https://dbhi.github.io/qus/references.html
- https://edaa-org.github.io/References.html