### PR TITLE
Basic implementation of VHDL output

### DIFF
--- a/src/pptrees/adder_tree.py
+++ b/src/pptrees/adder_tree.py
@@ -20,11 +20,16 @@ class adder_tree(prefix_tree):
         """
         super().__init__(width,network,node_defs,is_idem)
 
-    def _hdl_preamble(self):
+    def _hdl_preamble(self,language="verilog"):
         """Defines the preamble of the graph's HDL
 
         This method implements prefix_graph's counterpart for adders.
         """
+        if language=="verilog": return self._verilog_preamble()
+        if language=="vhdl": return self._vhdl_preamble()
+
+    def _verilog_preamble(self):
+        """Verilog preamble for the adder's HDL"""
 
         preamble = ""
         used_modules = set()
@@ -102,6 +107,106 @@ class adder_tree(prefix_tree):
 
         return (preamble,used_modules)
 
+    def _vhdl_preamble(self):
+        """VHDL preamble for the adder's HDL"""
+
+        preamble = ""
+        used_modules = set()
+
+        # Library imports
+        preamble += "library ieee;\n"
+        preamble += "use ieee.std_logic_1164.all;\n"
+        preamble += "use ieee.numeric_std;\n\n"
+
+        # Entity definition
+        preamble += "entity adder is\n"
+        preamble += "\tport (\n"
+        preamble += "\t\ta,b : in std_logic_vector({0} downto 0);\n".format(self.w-1)
+        preamble += "\t\tcin : in std_logic;\n"
+        preamble += "\t\tcout : out std_logic;\n"
+        preamble += "\t\tsum : out std_logic_vector({0} downto 0);\n".format(self.w-1)
+        preamble += "\t);\n"
+        preamble += "end entity;\n\n"
+
+        # Architecture definition
+        preamble += "architecture pptree of adder is\n"
+
+        # Wire definitions
+
+        # set of all wires
+        wire_set = set([e[2]['edge_name'] for e in self.edges(data=True)])
+
+        # Special-named wires
+        wires1 = "\tsignal"
+
+        # Generic-named wires
+        wires2 = "\tsignal"
+
+        # Sort wires by their origin
+        for x in wire_set:
+            if isinstance(x,int):
+                wires2 += " {0},".format(node._parse_net(x))
+            else:
+                wires1 += " {0},".format(node._parse_net(x))
+        wires1 = wires1[:-1] + " : std_logic;\n"
+        wires2 = wires2[:-1] + " : std_logic;\n"
+
+        # Add both kinds of wires to architecture definition
+        preamble += wires1
+        preamble += wires2
+        preamble += '\nbegin\n\n'
+
+        ### Add normal pre-processing nodes
+
+        # Iterate over all pre-processing nodes
+        for n in self.node_list[0]:
+            preamble += n.hdl(language="vhdl")+'\n'
+            used_modules.add(n.m)
+
+        preamble += '\n'
+
+        ### Add normal post-processing nodes
+
+        # Iterate over all post-processing nodes
+        for n in self.node_list[-1]:
+            n.ins['pin'][0]="$p{0}".format(n.x)
+            preamble += n.hdl(language="vhdl")+'\n'
+            used_modules.add(n.m)
+
+        preamble += '\n'
+
+        ### Add custom pre/post processing
+
+        # Additional pre node to handle cout
+	cout_pre = "\t{1}_cout: {1}\n"
+	cout_pre += "\t\tport map (\n"
+	cout_pre += "\t\t\ta_in => a({0}),\n"
+	cout_pre += "\t\t\tb_in => b({0}),\n"
+	cout_pre += "\t\t\tpout => p{0},\n"
+	cout_pre += "\t\t\tgout => g{0},\n"
+        cout_pre += "\t\t);\n"
+        cout_pre = cout_pre.format(self.w-1,self.node_defs['pre'])
+
+        preamble += cout_pre
+        used_modules.add(self.node_defs['pre'])
+
+        # Additional grey node to handle cout
+	cout_grey = "\t{2}_cout: {2}\n"
+	cout_grey += "\t\tport map (\n"
+	cout_grey += "\t\t\tgin(0) => {1},\n"
+	cout_grey += "\t\t\tgin(1) => g{0},\n"
+	cout_grey += "\t\t\tpin => p{0},\n"
+	cout_grey += "\t\t\tgout => cout,\n"
+        cout_grey += "\t\t);\n"
+        cout_g = node._parse_net(self.node_list[-1][-1].ins['gin'][0])
+        cout_grey = cout_grey.format(self.w-1,cout_g,self.node_defs['grey'])
+
+        preamble += cout_grey
+        used_modules.add(self.node_defs['grey'])
+
+        preamble += '\n'
+
+        return (preamble,used_modules)
 
 if __name__=="__main__":
     raise RuntimeError("This file is importable, but not executable")

--- a/src/pptrees/adder_tree.py
+++ b/src/pptrees/adder_tree.py
@@ -174,16 +174,16 @@ class adder_tree(prefix_tree):
             used_modules.add(n.m)
 
         preamble += '\n'
-
+        
         ### Add custom pre/post processing
-
+        
         # Additional pre node to handle cout
-	cout_pre = "\t{1}_cout: {1}\n"
-	cout_pre += "\t\tport map (\n"
-	cout_pre += "\t\t\ta_in => a({0}),\n"
-	cout_pre += "\t\t\tb_in => b({0}),\n"
-	cout_pre += "\t\t\tpout => p{0},\n"
-	cout_pre += "\t\t\tgout => g{0},\n"
+        cout_pre = "\t{1}_cout: {1}\n"
+        cout_pre += "\t\tport map (\n"
+        cout_pre += "\t\t\ta_in => a({0}),\n"
+        cout_pre += "\t\t\tb_in => b({0}),\n"
+        cout_pre += "\t\t\tpout => p{0},\n"
+        cout_pre += "\t\t\tgout => g{0},\n"
         cout_pre += "\t\t);\n"
         cout_pre = cout_pre.format(self.w-1,self.node_defs['pre'])
 
@@ -191,12 +191,12 @@ class adder_tree(prefix_tree):
         used_modules.add(self.node_defs['pre'])
 
         # Additional grey node to handle cout
-	cout_grey = "\t{2}_cout: {2}\n"
-	cout_grey += "\t\tport map (\n"
-	cout_grey += "\t\t\tgin(0) => {1},\n"
-	cout_grey += "\t\t\tgin(1) => g{0},\n"
-	cout_grey += "\t\t\tpin => p{0},\n"
-	cout_grey += "\t\t\tgout => cout,\n"
+        cout_grey = "\t{2}_cout: {2}\n"
+        cout_grey += "\t\tport map (\n"
+        cout_grey += "\t\t\tgin(0) => {1},\n"
+        cout_grey += "\t\t\tgin(1) => g{0},\n"
+        cout_grey += "\t\t\tpin => p{0},\n"
+        cout_grey += "\t\t\tgout => cout,\n"
         cout_grey += "\t\t);\n"
         cout_g = node._parse_net(self.node_list[-1][-1].ins['gin'][0])
         cout_grey = cout_grey.format(self.w-1,cout_g,self.node_defs['grey'])

--- a/src/pptrees/mappings/GTECH_map.v
+++ b/src/pptrees/mappings/GTECH_map.v
@@ -8,7 +8,7 @@ module inverter
 
     assign Y = ~A;
 
-endmodule : inverter
+endmodule
 
 // Buffer
 module buffer
@@ -20,7 +20,7 @@ module buffer
 
     GTECH_BUF buffer(.A(A), .Z(Y));
 
-endmodule: buffer
+endmodule
 
 // NAND2
 module nand2
@@ -32,7 +32,7 @@ module nand2
 
     GTECH_NAND2 nand2(.A(A), .B(B), .Z(Y));
 
-endmodule: nand2
+endmodule
 
 // NOR2
 module nor2
@@ -44,7 +44,7 @@ module nor2
 
     GTECH_NOR2 nor2(.A(A), .B(B), .Z(Y));
 
-endmodule: nor2
+endmodule
 
 // AND2
 module and2
@@ -56,7 +56,7 @@ module and2
 
     GTECH_AND2 and2(.A(A), .B(B), .Z(Y));
 
-endmodule: and2
+endmodule
 
 // OR2
 module or2
@@ -68,7 +68,7 @@ module or2
 
     GTECH_OR2 or2(.A(A), .B(B), .Z(Y));
 
-endmodule: or2
+endmodule
 
 // NAND3
 module nand3
@@ -80,7 +80,7 @@ module nand3
 
     GTECH_NAND3 nand3(.A(A), .B(B), .C(C), .Z(Y));
 
-endmodule: nand3
+endmodule
 
 // NOR3
 module nor3
@@ -92,7 +92,7 @@ module nor3
 
     GTECH_NOR3 nor3(.A(A), .B(B), .C(C), .Z(Y));
 
-endmodule: nor3
+endmodule
 
 // AND3
 module and3
@@ -104,7 +104,7 @@ module and3
 
     GTECH_AND3 and3(.A(A), .B(B), .C(C), .Z(Y));
 
-endmodule: and3
+endmodule
 
 // OR3
 module or3
@@ -116,7 +116,7 @@ module or3
 
     GTECH_OR3 or3(.A(A), .B(B), .C(C), .Z(Y));
 
-endmodule: or3
+endmodule
 
 // NAND4
 module nand4
@@ -128,7 +128,7 @@ module nand4
 
     GTECH_NAND4 nand4(.A(A), .B(B), .C(C), .D(D), .Z(Y));
 
-endmodule: nand4
+endmodule
 
 // NOR4
 module nor4
@@ -140,7 +140,7 @@ module nor4
 
     GTECH_NOR4 nor4(.A(A), .B(B), .C(C), .D(D), .Z(Y));
 
-endmodule: nor4
+endmodule
 
 // AND4
 module and4
@@ -152,7 +152,7 @@ module and4
 
     GTECH_AND4 and4(.A(A), .B(B), .C(C), .D(D), .Z(Y));
 
-endmodule: and4
+endmodule
 
 // OR4
 module or4
@@ -164,7 +164,7 @@ module or4
 
     GTECH_OR4 or4(.A(A), .B(B), .C(C), .D(D), .Z(Y));
 
-endmodule: or4
+endmodule
 
 // NAND2B
 module nand2b
@@ -176,7 +176,7 @@ module nand2b
 
     GTECH_AND_NOT nand2b(.A(B), .B(A), .Z(Y));
 
-endmodule: nand2b
+endmodule
 
 // NOR2B
 module nor2b
@@ -188,7 +188,7 @@ module nor2b
 
     GTECH_OR_NOT nor2b(.A(B), .B(A), .Z(Y));
 
-endmodule: nor2b
+endmodule
 
 // AO21
 module ao21
@@ -200,7 +200,7 @@ module ao21
 
     GTECH_AO21 ao21(.A(A0), .B(A1), .C(B0), .Z(Y));
 
-endmodule: ao21
+endmodule
 
 // OA21
 module oa21
@@ -212,7 +212,7 @@ module oa21
 
     GTECH_OA21 oa21(.A(A0), .B(A1), .C(B0), .Z(Y));
 
-endmodule: oa21
+endmodule
 
 // AOI21
 module aoi21
@@ -224,7 +224,7 @@ module aoi21
 
     GTECH_AOI21 aoi21(.A(A0), .B(A1), .C(B0), .Z(Y));
 
-endmodule: aoi21
+endmodule
 
 // OAI21
 module oai21
@@ -236,7 +236,7 @@ module oai21
 
     GTECH_OAI21 oai21(.A(A0), .B(A1), .C(B0), .Z(Y));
 
-endmodule: oai21
+endmodule
 
 // AO22
 module ao22
@@ -248,7 +248,7 @@ module ao22
 
     GTECH_AO22 ao22(.A(A0), .B(A1), .C(B0), .D(B1), .Z(Y));
 
-endmodule: ao22
+endmodule
 
 // OA22
 module oa22
@@ -260,7 +260,7 @@ module oa22
 
     GTECH_OA22 oa22(.A(A0), .B(A1), .C(B0), .D(B1), .Z(Y));
 
-endmodule: oa22
+endmodule
 
 // AOI22
 module aoi22
@@ -272,7 +272,7 @@ module aoi22
 
     GTECH_AOI22 aoi22(.A(A0), .B(A1), .C(B0), .D(B1), .Z(Y));
 
-endmodule: aoi22
+endmodule
 
 // OAI22
 module oai22
@@ -284,7 +284,7 @@ module oai22
 
     GTECH_OAI22 oai22(.A(A0), .B(A1), .C(B0), .D(B1), .Z(Y));
 
-endmodule: oai22
+endmodule
 
 // XOR2
 module xor2
@@ -296,7 +296,7 @@ module xor2
 
     GTECH_XOR2 xor2(.A(A), .B(B), .Z(Y));
 
-endmodule: xor2
+endmodule
 
 // XNOR2
 module xnor2
@@ -308,7 +308,7 @@ module xnor2
 
     GTECH_XNOR2 xnor2(.A(A), .B(B), .Z(Y));
 
-endmodule: xnor2
+endmodule
 
 // MUX2
 module mux2
@@ -320,7 +320,7 @@ module mux2
 
     GTECH_MUX2 mux2(.A(A), .B(B), .S(S), .Z(Y));
 
-endmodule: mux2
+endmodule
 
 // MUX2I
 module muxi2
@@ -332,4 +332,4 @@ module muxi2
 
     GTECH_MUXI2 muxi2(.A(A), .B(B), .S(S), .Z(Y));
 
-endmodule: muxi2
+endmodule

--- a/src/pptrees/mappings/behavioral_map.v
+++ b/src/pptrees/mappings/behavioral_map.v
@@ -8,7 +8,7 @@ module inverter
 
     assign Y = ~A;
 
-endmodule: inverter
+endmodule
 
 // Buffer
 module buffer
@@ -20,7 +20,7 @@ module buffer
 
     assign Y = A;
 
-endmodule: buffer
+endmodule
 
 // NAND2
 module nand2
@@ -32,7 +32,7 @@ module nand2
 
     assign Y = ~(A&B);
 
-endmodule: nand2
+endmodule
 
 // NOR2
 module nor2
@@ -44,7 +44,7 @@ module nor2
 
     assign Y = ~(A|B);
 
-endmodule: nor2
+endmodule
 
 // AND2
 module and2
@@ -56,7 +56,7 @@ module and2
 
     assign Y = A&B;
 
-endmodule: and2
+endmodule
 
 // OR2
 module or2
@@ -68,7 +68,7 @@ module or2
 
     assign Y = A|B;
 
-endmodule: or2
+endmodule
 
 // NAND3
 module nand3
@@ -80,7 +80,7 @@ module nand3
 
     assign Y = ~(A&B&C);
 
-endmodule: nand3
+endmodule
 
 // NOR3
 module nor3
@@ -92,7 +92,7 @@ module nor3
 
     assign Y = ~(A|B|C);
 
-endmodule: nor3
+endmodule
 
 // AND3
 module and3
@@ -104,7 +104,7 @@ module and3
 
     assign Y = A&B&C;
 
-endmodule: and3
+endmodule
 
 // OR3
 module or3
@@ -116,7 +116,7 @@ module or3
 
     assign Y = A|B|C;
 
-endmodule: or3
+endmodule
 
 // NAND4
 module nand4
@@ -128,7 +128,7 @@ module nand4
 
     assign Y = ~(A&B&C&D);
 
-endmodule: nand4
+endmodule
 
 // NOR4
 module nor4
@@ -140,7 +140,7 @@ module nor4
 
     assign Y = ~(A|B|C|D);
 
-endmodule: nor4
+endmodule
 
 // AND4
 module and4
@@ -152,7 +152,7 @@ module and4
 
     assign Y = A&B&C&D;
 
-endmodule: and4
+endmodule
 
 // OR4
 module or4
@@ -164,7 +164,7 @@ module or4
 
     assign Y = A|B|C|D;
 
-endmodule: or4
+endmodule
 
 // NAND2B
 module nand2b
@@ -176,7 +176,7 @@ module nand2b
 
     assign Y = ~(~A&B);
 
-endmodule: nand2b
+endmodule
 
 // NOR2B
 module nor2b
@@ -188,7 +188,7 @@ module nor2b
 
     assign Y = ~(~A|B);
 
-endmodule: nor2b
+endmodule
 
 // AO21
 module ao21
@@ -200,7 +200,7 @@ module ao21
 
     assign Y = (A0&A1)|B0;
 
-endmodule: ao21
+endmodule
 
 // OA21
 module oa21
@@ -212,7 +212,7 @@ module oa21
 
     assign Y = (A0|A1)&B0;
 
-endmodule: oa21
+endmodule
 
 // AOI21
 module aoi21
@@ -224,7 +224,7 @@ module aoi21
 
     assign Y = ~((A0&A1)|B0);
 
-endmodule: aoi21
+endmodule
 
 // OAI21
 module oai21
@@ -236,7 +236,7 @@ module oai21
 
     assign Y = ~((A0|A1)&B0);
 
-endmodule: oai21
+endmodule
 
 // AO22
 module ao22
@@ -248,7 +248,7 @@ module ao22
 
     assign Y = (A0&A1)|(B0&B1);
 
-endmodule: ao22
+endmodule
 
 // OA22
 module oa22
@@ -260,7 +260,7 @@ module oa22
 
     assign Y = (A0|A1)&(B0|B1);
 
-endmodule: oa22
+endmodule
 
 // AOI22
 module aoi22
@@ -272,7 +272,7 @@ module aoi22
 
     assign Y = ~((A0&A1)|(B0&B1));
 
-endmodule: aoi22
+endmodule
 
 // OAI22
 module oai22
@@ -284,7 +284,7 @@ module oai22
 
     assign Y = ~((A0|A1)&(B0|B1));
 
-endmodule: oai22
+endmodule
 
 // XOR2
 module xor2
@@ -296,7 +296,7 @@ module xor2
 
     assign Y = A^B;
 
-endmodule: xor2
+endmodule
 
 // XNOR2
 module xnor2
@@ -308,7 +308,7 @@ module xnor2
 
     assign Y = ~(A^B);
 
-endmodule: xnor2
+endmodule
 
 // MUX2
 module mux2
@@ -320,7 +320,7 @@ module mux2
 
     assign Y = S ? B : A;
 
-endmodule: mux2
+endmodule
 
 // MUX2I
 module muxi2
@@ -332,4 +332,4 @@ module muxi2
 
     assign Y = ~(S ? B : A);
 
-endmodule: muxi2
+endmodule

--- a/src/pptrees/mappings/behavioral_map.v
+++ b/src/pptrees/mappings/behavioral_map.v
@@ -8,7 +8,7 @@ module inverter
 
     assign Y = ~A;
 
-endmodule : inverter
+endmodule: inverter
 
 // Buffer
 module buffer

--- a/src/pptrees/mappings/behavioral_map.vhd
+++ b/src/pptrees/mappings/behavioral_map.vhd
@@ -1,0 +1,499 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity and2 is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of and2 is
+begin
+  Y <= A and B;
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity and3 is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    C : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of and3 is
+begin
+  Y <= A and B and C;
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity and4 is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    C : in std_logic;
+    D : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of and4 is
+begin
+  Y <= A and B and C and D;
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity ao21 is
+  port (
+    A0 : in std_logic;
+    A1 : in std_logic;
+    B0 : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of ao21 is
+begin
+  Y <= (A0 and A1) or B0;
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity ao22 is
+  port (
+    A0 : in std_logic;
+    A1 : in std_logic;
+    B0 : in std_logic;
+    B1 : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of ao22 is
+begin
+  Y <= (A0 and A1) or (B0 and B1);
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity aoi21 is
+  port (
+    A0 : in std_logic;
+    A1 : in std_logic;
+    B0 : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of aoi21 is
+begin
+  Y <= not ((A0 and A1) or B0);
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity aoi22 is
+  port (
+    A0 : in std_logic;
+    A1 : in std_logic;
+    B0 : in std_logic;
+    B1 : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of aoi22 is
+begin
+  Y <= not ((A0 and A1) or (B0 and B1));
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity buffer_module is
+  port (
+    A : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of buffer_module is
+begin
+  Y <= A;
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity inverter is
+  port (
+    A : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of inverter is
+begin
+  Y <= not A;
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity mux2 is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    S : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of mux2 is
+begin
+  Y <= B when S = '1' else A;
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity muxi2 is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    S : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+begin
+  Y <= not (B when S = '1' else A);
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity nand2 is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of nand2 is
+begin
+  Y <= not (A and B);
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity nand2b is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of nand2b is
+begin
+  Y <= not (not A and B);
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity nand3 is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    C : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of nand3 is
+begin
+  Y <= not (A and B and C);
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity nand4 is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    C : in std_logic;
+    D : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of nand4 is
+begin
+  Y <= not (A and B and C and D);
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity nor2 is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of nor2 is
+begin
+  Y <= not (A or B);
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity nor2b is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of nor2b is
+begin
+  Y <= not (not A or B);
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity nor3 is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    C : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of nor3 is
+begin
+  Y <= not (A or B or C);
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity nor4 is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    C : in std_logic;
+    D : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of nor4 is
+begin
+  Y <= not (A or B or C or D);
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity oa21 is
+  port (
+    A0 : in std_logic;
+    A1 : in std_logic;
+    B0 : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of oa21 is
+begin
+  Y <= (A0 or A1) and B0;
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity oa22 is
+  port (
+    A0 : in std_logic;
+    A1 : in std_logic;
+    B0 : in std_logic;
+    B1 : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of oa22 is
+begin
+  Y <= (A0 or A1) and (B0 or B1);
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity oai21 is
+  port (
+    A0 : in std_logic;
+    A1 : in std_logic;
+    B0 : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of oai21 is
+begin
+  Y <= not ((A0 or A1) and B0);
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity oai22 is
+  port (
+    A0 : in std_logic;
+    A1 : in std_logic;
+    B0 : in std_logic;
+    B1 : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of oai22 is
+begin
+  Y <= not (A0 or A1) and (B0 or B1);
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity or2 is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of or2 is
+begin
+  Y <= A or B;
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity or3 is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    C : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of or3 is
+begin
+  Y <= A or B or C;
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity or4 is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    C : in std_logic;
+    D : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of or4 is
+begin
+  Y <= A or B or C or D;
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity xnor2 is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of xnor2 is
+begin
+  Y <= not (A xor B);
+end architecture;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity xor2 is
+  port (
+    A : in std_logic;
+    B : in std_logic;
+    Y : out std_logic
+  );
+end entity; 
+
+architecture behavior of xor2 is
+begin
+  Y <= A xor B;
+end architecture;
+

--- a/src/pptrees/mappings/sky130_fd_sc_hd_map.v
+++ b/src/pptrees/mappings/sky130_fd_sc_hd_map.v
@@ -8,7 +8,7 @@ module inverter
 
     sky130_fd_sc_hd__inv_1 inverter(.Y(Y), .A(A));
 
-endmodule : inverter
+endmodule
 
 // Buffer
 module buffer
@@ -20,7 +20,7 @@ module buffer
 
     sky130_fd_sc_hd__buf_1 buffer(.X(Y), .A(A));
 
-endmodule: buffer
+endmodule
 
 // NAND2
 module nand2
@@ -32,7 +32,7 @@ module nand2
 
     sky130_fd_sc_hd__nand2_1 nand2(.Y(Y), .A(A), .B(B));
 
-endmodule: nand2
+endmodule
 
 // NOR2
 module nor2
@@ -44,7 +44,7 @@ module nor2
 
     sky130_fd_sc_hd__nor2_1 nor2(.Y(Y), .A(A), .B(B));
 
-endmodule: nor2
+endmodule
 
 // AND2
 module and2
@@ -56,7 +56,7 @@ module and2
 
     sky130_fd_sc_hd__and2_1 and2(.X(Y), .A(A), .B(B));
 
-endmodule: and2
+endmodule
 
 // OR2
 module or2
@@ -68,7 +68,7 @@ module or2
 
     sky130_fd_sc_hd__or2_1 or2(.X(Y), .A(A), .B(B));
 
-endmodule: or2
+endmodule
 
 // NAND3
 module nand3
@@ -80,7 +80,7 @@ module nand3
 
     sky130_fd_sc_hd__nand3_1 nand3(.Y(Y), .A(A), .B(B), .C(C));
 
-endmodule: nand3
+endmodule
 
 // NOR3
 module nor3
@@ -92,7 +92,7 @@ module nor3
 
     sky130_fd_sc_hd__nor3_1 nor3(.Y(Y), .A(A), .B(B), .C(C));
 
-endmodule: nor3
+endmodule
 
 // AND3
 module and3
@@ -104,7 +104,7 @@ module and3
 
     sky130_fd_sc_hd__and3_1 and3(.X(Y), .A(A), .B(B), .C(C));
 
-endmodule: and3
+endmodule
 
 // OR3
 module or3
@@ -116,7 +116,7 @@ module or3
 
     sky130_fd_sc_hd__or3_1 or3(.X(Y), .A(A), .B(B), .C(C));
 
-endmodule: or3
+endmodule
 
 // NAND4
 module nand4
@@ -128,7 +128,7 @@ module nand4
 
     sky130_fd_sc_hd__nand4_1 nand4(.Y(Y), .A(A), .B(B), .C(C), .D(D));
 
-endmodule: nand4
+endmodule
 
 // NOR4
 module nor4
@@ -140,7 +140,7 @@ module nor4
 
     sky130_fd_sc_hd__nor4_1 nor4(.Y(Y), .A(A), .B(B), .C(C), .D(D));
 
-endmodule: nor4
+endmodule
 
 // AND4
 module and4
@@ -152,7 +152,7 @@ module and4
 
     sky130_fd_sc_hd__and4_1 and4(.X(Y), .A(A), .B(B), .C(C), .D(D));
 
-endmodule: and4
+endmodule
 
 // OR4
 module or4
@@ -164,7 +164,7 @@ module or4
 
     sky130_fd_sc_hd__or4_1 or4(.X(Y), .A(A), .B(B), .C(C), .D(D));
 
-endmodule: or4
+endmodule
 
 // NAND2B
 module nand2b
@@ -176,7 +176,7 @@ module nand2b
 
     sky130_fd_sc_hd__nand2b_1 nand2b(.Y(Y), .A_N(A), .B(B));
 
-endmodule: nand2b
+endmodule
 
 // NOR2B
 module nor2b
@@ -188,7 +188,7 @@ module nor2b
 
     sky130_fd_sc_hd__nor2b_1 nor2b(.Y(Y), .A(B), .B_N(A));
 
-endmodule: nor2b
+endmodule
 
 // AO21
 module ao21
@@ -200,7 +200,7 @@ module ao21
 
     sky130_fd_sc_hd__a21o_1 ao21(.X(Y), .A1(A0), .A2(A1), .B1(B0));
 
-endmodule: ao21
+endmodule
 
 // OA21
 module oa21
@@ -212,7 +212,7 @@ module oa21
 
     sky130_fd_sc_hd__o21a_1 oa21(.X(Y), .A1(A0), .A2(A1), .B1(B0));
 
-endmodule: oa21
+endmodule
 
 // AOI21
 module aoi21
@@ -224,7 +224,7 @@ module aoi21
 
     sky130_fd_sc_hd__a21oi_1 aoi21(.Y(Y), .A1(A0), .A2(A1), .B1(B0));
 
-endmodule: aoi21
+endmodule
 
 // OAI21
 module oai21
@@ -236,7 +236,7 @@ module oai21
 
     sky130_fd_sc_hd__o21ai_1 oai21(.X(Y), .A1(A0), .A2(A1), .B1(B0));
 
-endmodule: oai21
+endmodule
 
 // AO22
 module ao22
@@ -248,7 +248,7 @@ module ao22
 
     sky130_fd_sc_hd__a22o_1 ao22(.X(Y), .A1(A0), .A2(A1), .B1(B0), .B2(B1));
 
-endmodule: ao22
+endmodule
 
 // OA22
 module oa22
@@ -260,7 +260,7 @@ module oa22
 
     sky130_fd_sc_hd__o22a_1 oa22(.X(Y), .A1(A0), .A2(A1), .B1(B0), .B2(B1));
 
-endmodule: oa22
+endmodule
 
 // AOI22
 module aoi22
@@ -272,7 +272,7 @@ module aoi22
 
     sky130_fd_sc_hd__a22oi_1 aoi22(.Y(Y), .A1(A0), .A2(A1), .B1(B0), .B2(B1));
 
-endmodule: aoi22
+endmodule
 
 // OAI22
 module oai22
@@ -284,7 +284,7 @@ module oai22
 
     sky130_fd_sc_hd__o22ai_1 oai22(.Y(Y), .A1(A0), .A2(A1), .B1(B0), .B2(B1));
 
-endmodule: oai22
+endmodule
 
 // XOR2
 module xor2
@@ -296,7 +296,7 @@ module xor2
 
     sky130_fd_sc_hd__xor2_1 xor2(.X(Y), .A(A), .B(B));
 
-endmodule: xor2
+endmodule
 
 // XNOR2
 module xnor2
@@ -308,7 +308,7 @@ module xnor2
 
     sky130_fd_sc_hd__xnor2_1 xnor2(.Y(Y), .A(A), .B(B));
 
-endmodule: xnor2
+endmodule
 
 // MUX2
 module mux2
@@ -320,7 +320,7 @@ module mux2
 
     sky130_fd_sc_hd__mux2_1 mux2(.X(Y), .S(S), .A0(A), .A1(B));
 
-endmodule: mux2
+endmodule
 
 // MUX2I
 module muxi2
@@ -332,4 +332,4 @@ module muxi2
 
     sky130_fd_sc_hd__mux2i_1 muxi2(.Y(Y), .S(S), .A0(A), .A1(B));
 
-endmodule: muxi2
+endmodule

--- a/src/pptrees/mappings/sky130_fd_sc_hs_map.v
+++ b/src/pptrees/mappings/sky130_fd_sc_hs_map.v
@@ -8,7 +8,7 @@ module inverter
 
     sky130_fd_sc_hs__inv_1 inverter(.Y(Y), .A(A));
 
-endmodule : inverter
+endmodule
 
 // Buffer
 module buffer
@@ -20,7 +20,7 @@ module buffer
 
     sky130_fd_sc_hs__buf_1 buffer(.X(Y), .A(A));
 
-endmodule: buffer
+endmodule
 
 // NAND2
 module nand2
@@ -32,7 +32,7 @@ module nand2
 
     sky130_fd_sc_hs__nand2_1 nand2(.Y(Y), .A(A), .B(B));
 
-endmodule: nand2
+endmodule
 
 // NOR2
 module nor2
@@ -44,7 +44,7 @@ module nor2
 
     sky130_fd_sc_hs__nor2_1 nor2(.Y(Y), .A(A), .B(B));
 
-endmodule: nor2
+endmodule
 
 // AND2
 module and2
@@ -56,7 +56,7 @@ module and2
 
     sky130_fd_sc_hs__and2_1 and2(.X(Y), .A(A), .B(B));
 
-endmodule: and2
+endmodule
 
 // OR2
 module or2
@@ -68,7 +68,7 @@ module or2
 
     sky130_fd_sc_hs__or2_1 or2(.X(Y), .A(A), .B(B));
 
-endmodule: or2
+endmodule
 
 // NAND3
 module nand3
@@ -80,7 +80,7 @@ module nand3
 
     sky130_fd_sc_hs__nand3_1 nand3(.Y(Y), .A(A), .B(B), .C(C));
 
-endmodule: nand3
+endmodule
 
 // NOR3
 module nor3
@@ -92,7 +92,7 @@ module nor3
 
     sky130_fd_sc_hs__nor3_1 nor3(.Y(Y), .A(A), .B(B), .C(C));
 
-endmodule: nor3
+endmodule
 
 // AND3
 module and3
@@ -104,7 +104,7 @@ module and3
 
     sky130_fd_sc_hs__and3_1 and3(.X(Y), .A(A), .B(B), .C(C));
 
-endmodule: and3
+endmodule
 
 // OR3
 module or3
@@ -116,7 +116,7 @@ module or3
 
     sky130_fd_sc_hs__or3_1 or3(.X(Y), .A(A), .B(B), .C(C));
 
-endmodule: or3
+endmodule
 
 // NAND4
 module nand4
@@ -128,7 +128,7 @@ module nand4
 
     sky130_fd_sc_hs__nand4_1 nand4(.Y(Y), .A(A), .B(B), .C(C), .D(D));
 
-endmodule: nand4
+endmodule
 
 // NOR4
 module nor4
@@ -140,7 +140,7 @@ module nor4
 
     sky130_fd_sc_hs__nor4_1 nor4(.Y(Y), .A(A), .B(B), .C(C), .D(D));
 
-endmodule: nor4
+endmodule
 
 // AND4
 module and4
@@ -152,7 +152,7 @@ module and4
 
     sky130_fd_sc_hs__and4_1 and4(.X(Y), .A(A), .B(B), .C(C), .D(D));
 
-endmodule: and4
+endmodule
 
 // OR4
 module or4
@@ -164,7 +164,7 @@ module or4
 
     sky130_fd_sc_hs__or4_1 or4(.X(Y), .A(A), .B(B), .C(C), .D(D));
 
-endmodule: or4
+endmodule
 
 // NAND2B
 module nand2b
@@ -176,7 +176,7 @@ module nand2b
 
     sky130_fd_sc_hs__nand2b_1 nand2b(.Y(Y), .A_N(A), .B(B));
 
-endmodule: nand2b
+endmodule
 
 // NOR2B
 module nor2b
@@ -188,7 +188,7 @@ module nor2b
 
     sky130_fd_sc_hs__nor2b_1 nor2b(.Y(Y), .A(B), .B_N(A));
 
-endmodule: nor2b
+endmodule
 
 // AO21
 module ao21
@@ -200,7 +200,7 @@ module ao21
 
     sky130_fd_sc_hs__a21o_1 ao21(.X(Y), .A1(A0), .A2(A1), .B1(B0));
 
-endmodule: ao21
+endmodule
 
 // OA21
 module oa21
@@ -212,7 +212,7 @@ module oa21
 
     sky130_fd_sc_hs__o21a_1 oa21(.X(Y), .A1(A0), .A2(A1), .B1(B0));
 
-endmodule: oa21
+endmodule
 
 // AOI21
 module aoi21
@@ -224,7 +224,7 @@ module aoi21
 
     sky130_fd_sc_hs__a21oi_1 aoi21(.Y(Y), .A1(A0), .A2(A1), .B1(B0));
 
-endmodule: aoi21
+endmodule
 
 // OAI21
 module oai21
@@ -236,7 +236,7 @@ module oai21
 
     sky130_fd_sc_hs__o21ai_1 oai21(.X(Y), .A1(A0), .A2(A1), .B1(B0));
 
-endmodule: oai21
+endmodule
 
 // AO22
 module ao22
@@ -248,7 +248,7 @@ module ao22
 
     sky130_fd_sc_hs__a22o_1 ao22(.X(Y), .A1(A0), .A2(A1), .B1(B0), .B2(B1));
 
-endmodule: ao22
+endmodule
 
 // OA22
 module oa22
@@ -260,7 +260,7 @@ module oa22
 
     sky130_fd_sc_hs__o22a_1 oa22(.X(Y), .A1(A0), .A2(A1), .B1(B0), .B2(B1));
 
-endmodule: oa22
+endmodule
 
 // AOI22
 module aoi22
@@ -272,7 +272,7 @@ module aoi22
 
     sky130_fd_sc_hs__a22oi_1 aoi22(.Y(Y), .A1(A0), .A2(A1), .B1(B0), .B2(B1));
 
-endmodule: aoi22
+endmodule
 
 // OAI22
 module oai22
@@ -284,7 +284,7 @@ module oai22
 
     sky130_fd_sc_hs__o22ai_1 oai22(.Y(Y), .A1(A0), .A2(A1), .B1(B0), .B2(B1));
 
-endmodule: oai22
+endmodule
 
 // XOR2
 module xor2
@@ -296,7 +296,7 @@ module xor2
 
     sky130_fd_sc_hs__xor2_1 xor2(.X(Y), .A(A), .B(B));
 
-endmodule: xor2
+endmodule
 
 // XNOR2
 module xnor2
@@ -308,7 +308,7 @@ module xnor2
 
     sky130_fd_sc_hs__xnor2_1 xnor2(.Y(Y), .A(A), .B(B));
 
-endmodule: xnor2
+endmodule
 
 // MUX2
 module mux2
@@ -320,7 +320,7 @@ module mux2
 
     sky130_fd_sc_hs__mux2_1 mux2(.X(Y), .S(S), .A0(A), .A1(B));
 
-endmodule: mux2
+endmodule
 
 // MUX2I
 module muxi2
@@ -332,4 +332,4 @@ module muxi2
 
     sky130_fd_sc_hs__mux2i_1 muxi2(.Y(Y), .S(S), .A0(A), .A1(B));
 
-endmodule: muxi2
+endmodule

--- a/src/pptrees/modules.py
+++ b/src/pptrees/modules.py
@@ -19,6 +19,37 @@ module ppa_black(gin, pin, gout, pout);
 endmodule
 """
 
+ppa_black['vhdl']="""
+entity ppa_black is
+\tport (
+\t\tgin : in std_logic_vector(1 downto 0);
+\t\tgout : out std_logic;
+\t\tpin : in std_logic_vector(1 downto 0);
+\t\tpout : out std_logic
+\t);
+end entity;
+
+architecture behavior of ppa_black is
+begin
+
+U1: and2
+\tport map (
+\t\tA => pin_0,
+\t\tB => pin_1,
+\t\tY => pout
+\t);
+
+U2: ao21
+\tport map (
+\t\tA0 => gin_0,
+\t\tA1 => pin_1,
+\t\tB0 => gin_1,
+\t\tY => gout
+\t);
+
+end architecture;
+"""
+
 ppa_black['shape']='square'
 ppa_black['fillcolor']='black'
 
@@ -66,6 +97,29 @@ module ppa_grey(gin, pin, gout);
 endmodule
 """
 
+ppa_grey['vhdl']="""
+entity ppa_grey is
+\tport (
+\t\tgin : in std_logic_vector(1 downto 0);
+\t\tgout : out std_logic;
+\t\tpin : in std_logic;
+\t);
+end entity;
+
+architecture behavior of ppa_grey is
+begin
+
+U1: ao21
+\tport map (
+\t\tA0 => gin_0,
+\t\tA1 => pin,
+\t\tB0 => gin_1,
+\t\tY => gout
+\t);
+
+end architecture;
+"""
+
 ppa_grey['shape']='square'
 ppa_grey['fillcolor']='grey'
 
@@ -99,19 +153,49 @@ modules['ppa_grey']=ppa_grey
 ppaL_black=dict()
 
 ppaL_black['verilog']="""
-module ppaL_black(hout, iout, gin, pin);
+module ppaL_black(gout, pout, gin, pin);
 
 \tinput [1:0] gin, pin;
-\toutput hout, iout;
+\toutput gout, pout;
 
-\tand2 U1(iout,pin[0],pin[1]);
-\tor2 U2(hout,gin[0],gin[1]);
+\tand2 U1(pout,pin[0],pin[1]);
+\tor2 U2(gout,gin[0],gin[1]);
 
 endmodule
 """
 
+ppaL_black['vhdl']="""
+entity ppaL_black is
+\tport (
+\t\tgin : in std_logic_vector(1 downto 0);
+\t\tgout : out std_logic;
+\t\tpin : in std_logic_vector(1 downto 0);
+\t\tpout : out std_logic
+\t);
+end entity;
+
+architecture behavior of ppaL_black is
+begin
+
+U1: and2
+\tport map (
+\t\tA => pin_0,
+\t\tB => pin_1,
+\t\tY => pout
+\t);
+
+U2: or2
+\tport map (
+\t\tA => gin_0,
+\t\tB => gin_1,
+\t\tY => gout
+\t);
+
+end architecture;
+"""
+
 ppaL_black['shape']='square'
-ppaL_black['fillcolor']='ppa_black'
+ppaL_black['fillcolor']='black'
 
 # List of inputs represented by (name, bits) tuple
 ppaL_black['ins']=[('gin',2),('pin',2)]
@@ -154,8 +238,30 @@ module ppaL_grey(hout, gin);
 endmodule
 """
 
+ppaL_grey['vhdl']="""
+entity ppaL_grey is
+\tport (
+\t\tgin : in std_logic_vector(1 downto 0);
+\t\tgout : out std_logic;
+\t\tpin : in std_logic;
+\t);
+end entity;
+
+architecture behavior of ppaL_grey is
+begin
+
+U1: or2
+\tport map (
+\t\tA => gin_0,
+\t\tB => gin_1,
+\t\tY => gout
+\t);
+
+end architecture;
+"""
+
 ppaL_grey['shape']='square'
-ppaL_grey['fillcolor']='ppa_grey'
+ppaL_grey['fillcolor']='grey'
 
 # List of inputs represented by (name, bits) tuple
 ppaL_grey['ins']=[('gin',2)]
@@ -198,6 +304,34 @@ module buffer_node(pin, gin, pout, gout);
 endmodule
 """
 
+buffer_node['vhdl']="""
+entity buffer_node is
+\tport (
+\t\tpin : in std_logic;
+\t\tpout : out std_logic;
+\t\tgin : in std_logic;
+\t\tgout : out std_logic;
+\t);
+end entity;
+
+architecture behavior of buffer_node is
+begin
+
+U1: buffer
+\tport map (
+\t\tA => pin,
+\t\tY => pout
+\t);
+
+U2: buffer
+\tport map (
+\t\tA => gin,
+\t\tY => gout
+\t);
+
+end architecture;
+"""
+
 buffer_node['shape']='invtriangle'
 buffer_node['fillcolor']='white'
 
@@ -234,6 +368,25 @@ module invis_node(pin, gin, pout, gout);
 \tassign gout = gin;
 
 endmodule
+"""
+
+invis_node['vhdl']="""
+entity invis_node is
+\tport (
+\t\tgin : in std_logic;
+\t\tgout : out std_logic;
+\t\tpin : in std_logic;
+\t\tpout : out std_logic;
+\t);
+end entity;
+
+architecture behavior of invis_node is
+begin
+
+\tpout <= pin;
+\tgout <= gin;
+
+end architecture;
 """
 
 #invis_node['style']='invis'
@@ -276,6 +429,36 @@ module ppa_pre(a_in, b_in, pout, gout);
 \tand2 U2(gout,a_in,b_in);
 
 endmodule
+"""
+
+ppa_pre['vhdl']="""
+entity ppa_pre is
+\tport (
+\t\ta_in : in std_logic;
+\t\tb_in : in std_logic;
+\t\tpout : out std_logic;
+\t\tgout : out std_logic;
+\t);
+end entity;
+
+architecture behavior of ppa_pre is
+begin
+
+U1: xor2
+\tport map (
+\t\tA => a_in,
+\t\tB => b_in,
+\t\tY => pout
+\t);
+
+U2: and2
+\tport map (
+\t\tA => a_in,
+\t\tB => b_in,
+\t\tY => gout
+\t);
+
+end architecture;
 """
 
 ppa_pre['shape']='square'
@@ -321,6 +504,24 @@ module ppa_first_pre(cin, pout, gout);
 endmodule
 """
 
+ppa_first_pre['vhdl']="""
+entity ppa_first_pre is
+\tport (
+\t\tcin : in std_logic;
+\t\tpout : out std_logic;
+\t\tgout : out std_logic;
+\t);
+end entity;
+
+architecture behavior of ppa_first_pre is
+begin
+
+\tpout <= '0';
+\tgout <= cin;
+
+end architecture;
+"""
+
 ppa_first_pre['ins']=[('cin',1)]
 
 ppa_first_pre['logic'] = lambda cin: [0,cin]
@@ -340,6 +541,28 @@ module ppa_post(pin, gin, sum);
 \txor2 U1(sum,pin,gin);
 
 endmodule
+"""
+
+ppa_post['vhdl']="""
+entity ppa_post is
+\tport (
+\t\tpin : in std_logic;
+\t\tgin : in std_logic;
+\t\tsum : out std_logic;
+\t);
+end entity;
+
+architecture behavior of ppa_post is
+begin
+
+U1: xor2
+\tport map (
+\t\tA => pin,
+\t\tB => gin,
+\t\tY => sum
+\t);
+
+end architecture;
 """
 
 ppa_post['shape']='invtrapezium'

--- a/src/pptrees/modules.py
+++ b/src/pptrees/modules.py
@@ -34,16 +34,16 @@ begin
 
 U1: and2
 \tport map (
-\t\tA => pin_0,
-\t\tB => pin_1,
+\t\tA => pin(0),
+\t\tB => pin(1),
 \t\tY => pout
 \t);
 
 U2: ao21
 \tport map (
-\t\tA0 => gin_0,
-\t\tA1 => pin_1,
-\t\tB0 => gin_1,
+\t\tA0 => gin(0),
+\t\tA1 => pin(1),
+\t\tB0 => gin(1),
 \t\tY => gout
 \t);
 
@@ -111,9 +111,9 @@ begin
 
 U1: ao21
 \tport map (
-\t\tA0 => gin_0,
+\t\tA0 => gin(0),
 \t\tA1 => pin,
-\t\tB0 => gin_1,
+\t\tB0 => gin(1),
 \t\tY => gout
 \t);
 
@@ -179,15 +179,15 @@ begin
 
 U1: and2
 \tport map (
-\t\tA => pin_0,
-\t\tB => pin_1,
+\t\tA => pin(0),
+\t\tB => pin(1),
 \t\tY => pout
 \t);
 
 U2: or2
 \tport map (
-\t\tA => gin_0,
-\t\tB => gin_1,
+\t\tA => gin(0),
+\t\tB => gin(1),
 \t\tY => gout
 \t);
 
@@ -252,8 +252,8 @@ begin
 
 U1: or2
 \tport map (
-\t\tA => gin_0,
-\t\tB => gin_1,
+\t\tA => gin(0),
+\t\tB => gin(1),
 \t\tY => gout
 \t);
 

--- a/src/pptrees/prefix_graph.py
+++ b/src/pptrees/prefix_graph.py
@@ -111,12 +111,13 @@ class prefix_node():
 
         # Format net IDs and add them to module instantation line
         for a in pins:
-            for b in range(len(pin[a])):
+            for b in range(len(pins[a])):
                 net_name = prefix_node._parse_net(pins[a][b])
                 ret+="\n\t\t\t{0}({1}) => {2},".format(a,b,net_name)
 
         # Close parenthesis
-        ret[:-1]+="\n\t\t);"
+        ret=ret[:-1]
+        ret+="\n\t\t);"
 
         return ret
 
@@ -135,9 +136,12 @@ class prefix_node():
         ret = ''
 
         for l in hdl_def:
-            if 'U' in l: in_std_cell = True
-            if in_std_cell == True: ret += l
-            if l[-1] == ';': in_std_cell = False
+            if 'assign' in l or '<=' in l:
+                ret+=l+'\n'
+            else:
+                if 'U' in l: in_std_cell = True
+                if in_std_cell == True: ret += l+'\n'
+                if l!='' and l[-1] == ';': in_std_cell = False
 
         # Create list of all instance pins and copy in unformatted net IDs
         pins=self.ins.copy()
@@ -153,7 +157,7 @@ class prefix_node():
                     net_name=prefix_node._parse_net(pins[a][b])
                     ret=ret.replace("{0}[{1}]".format(a,b),net_name)
 
-        return ret
+        return ret[:-1]
 
     def flatten(self,flag=True):
         """Determine which verilog representation to output"""
@@ -161,7 +165,7 @@ class prefix_node():
 
     def hdl(self,language="verilog"):
         """Return HDL representation of node"""
-        if self.flat: return self.flat()
+        if self.flat: return self._flat()
         if language == 'verilog': return self._verilog()
         if language == 'vhdl': return self._vhdl()
 


### PR DESCRIPTION
The commits in this PR update the HDL-generation code to be able to handle multiple languages.

VHDL is implemented. Items remaining to be done:

- Support direct cell-mapping in VHDL (currently only supports the "behavioral" map, rather than technology-specific mapping).
- Test thoroughly.
- Run VHDL output through a style checker
- Set up automatic equivalence checking, likely by using iverilog to convert VHDL output to Verilog and then running both versions through an equivalence checker.
-  Support other languages.