### PR TITLE
Downgrading NetworkX requirement until March 7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     long_description=open('README.md').read(),
     python_requires='>=3.7.*',
     install_requires=[
-        "networkx",
+        "networkx==2.6.3",
         "pydot",
         "graphviz"
     ]


### PR DESCRIPTION
Required due to CI incompatibility with NetworkX 2.7.0

NetworkX 2.7.1 planned release date is March 7