### PR TITLE
Fix config.yml to only refer to python3

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: '3.x'
     - name: Display Python version
       run: |
-        python -m pip install --upgrade pip
-        pip install .
+        python3 -m pip install --upgrade pip
+        python3 -m pip install .
         python3 unit_tests/node_test.py
         python3 unit_tests/tree_test.py


### PR DESCRIPTION
Useful to remove possible `python` vs `python3` ambiguities. Thanks @rossbar !