### PR TITLE
Improvements for Yosys plugin

### DIFF
--- a/src/pptrees/prefix_graph.py
+++ b/src/pptrees/prefix_graph.py
@@ -651,8 +651,8 @@ class prefix_graph(nx.MultiDiGraph):
             file_suffix = ".vhd"
 
         # Locate mapping file and check its existence
-        with importlib.resources.path("pptrees", "mappings") as pkg_map_dir:
-            pkg_map_file = pkg_map_dir / (mapping + "_map" + file_suffix)
+        map_file = mapping + "_map" + file_suffix
+        with importlib.resources.path("pptrees.mappings", map_file) as pkg_map_file:
             local_map_file = outdir / (mapping + "_map" + file_suffix)
 
             if not pkg_map_file.is_file():

--- a/src/pptrees/yosys_alu.py
+++ b/src/pptrees/yosys_alu.py
@@ -14,6 +14,14 @@ class yosys_alu(adder_tree):
 
         Refer to the adder_tree's docstring for a full description.
         """
+        if network == "very_slow":
+            network = "ripple"
+        elif network == "slow":
+            network = "brent-kung"
+        elif network == "fast":
+            network = "sklansky"
+        elif network == "very_fast":
+            network = "kogge-stone"
         super().__init__(width, network)
 
     def yosys_map(self, out=None, mapping="behavioral"):


### PR DESCRIPTION
Python 3.9 importlib bug from [yosys_prefix_trees #10](https://github.com/lnis-uofu/yosys_prefix_trees/issues/10) should be universally fixed now.

Added short-hand recipes for networks:

- very_slow maps to ripple-carry
- slow maps to brent-kung
- fast maps to sklansky
- very_fast maps to kogge-stone